### PR TITLE
chore: update required node version to 16 from 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "codewars nodejs api client, with types",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
Force supported engines to be 16 or greater, than 12. 

Node 12 has been out of support for a long period of time, so it should be ok to move over. Will create a new minor version release. 